### PR TITLE
IMBiPhotoObjectPromise called _didFinish twice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+
+.DS_Store
+
+*.xcuserdatad
+xcschememanagement.plist

--- a/IMBiPhotoObjectPromise.m
+++ b/IMBiPhotoObjectPromise.m
@@ -90,13 +90,6 @@
 	return self;
 }
 
-- (void) loadObjects:(NSArray*)inObjects
-{
-	[super loadObjects:inObjects];
-	[self _didFinish];
-}
-
-
 - (void) _loadObject:(IMBObject*)inObject
 {
     id parser = [inObject parser];


### PR DESCRIPTION
Both IMBiPhotoObjectPromise and its superclass called _didFinish causing delegates to be notified twice
