### PR TITLE
Migrated parserForObject: to superclass so it is available for all parsers

### DIFF
--- a/IMBApertureParser.m
+++ b/IMBApertureParser.m
@@ -446,14 +446,14 @@
 		
 		if ([albumType isEqualToString:@"5"])
 		{
-			rootNodeIdentifier = [self identifierForId:albumId inSpace:nil];
+			rootNodeIdentifier = [[self identifierForId:albumId inSpace:nil] retain];
 		}
 
 		[pool drain];
 		
 		if (rootNodeIdentifier != nil)
 		{
-			return rootNodeIdentifier;
+			return [rootNodeIdentifier autorelease];
 		}
 	}
 

--- a/IMBApertureParser.m
+++ b/IMBApertureParser.m
@@ -442,13 +442,19 @@
 		NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
 		NSString* albumType = [albumDict objectForKey:@"Album Type"];
 		NSNumber* albumId = [albumDict objectForKey:@"AlbumId"];
+		NSString* rootNodeIdentifier = nil;
 		
 		if ([albumType isEqualToString:@"5"])
 		{
-			return [self identifierForId:albumId inSpace:nil];
+			rootNodeIdentifier = [self identifierForId:albumId inSpace:nil];
 		}
 
 		[pool drain];
+		
+		if (rootNodeIdentifier != nil)
+		{
+			return rootNodeIdentifier;
+		}
 	}
 
 	// Fallback if nothing is found...

--- a/IMBProject.xcconfig
+++ b/IMBProject.xcconfig
@@ -8,7 +8,7 @@
 // is now referencing your own set of xcconfig files.
 
 
-ARCHS = ppc i386 x86_64
+ARCHS = i386 x86_64
 SDKROOT = macosx10.6
 MACOSX_DEPLOYMENT_TARGET = 10.5
 PREBINDING = NO

--- a/IMBiPhotoObjectPromise.m
+++ b/IMBiPhotoObjectPromise.m
@@ -55,8 +55,6 @@
 #import "IMBiPhotoObjectPromise.h"
 #import "IMBiPhotoParser.h"
 
-#import "IMBParserController.h"
-
 #import "NSString+iMedia.h"
 
 
@@ -76,9 +74,6 @@
 @end
 
 
-// This subclass is used for pyramid files that need to be split. The split file is saved to the local file system,
-// where it can then be accessed by the delegate... 
-
 #pragma mark
 
 @implementation IMBiPhotoObjectPromise
@@ -92,37 +87,9 @@
 	return self;
 }
 
-- (IMBParser *)parserForObject:(IMBObject *)object;
-{
-    IMBParser *result = [object parser];
-    if (result) return result;
-    
-    
-    // IMBObjectsPromise creates objects by unarchiving them. Unarchived objects do not contain a reference to their parser, only the parser type and media source. Thus, we have to guess at the parser here so clients can have access to it.
-    NSString *parserMediaType = object.parserMediaType;
-    NSString *parserMediaSource = object.parserMediaSource;
-    
-    if ((parserMediaType == nil) || (parserMediaSource == nil)) {
-        return nil;
-    }
-    
-    IMBParserController *parserController = [IMBParserController sharedParserController];
-    NSArray *loadedParsers = [parserController parsersForMediaType:parserMediaType];
-    
-    for (IMBParser *parser in loadedParsers) {
-        if ([parser.mediaSource isEqualToString:parserMediaSource])
-        {
-            [object setParser:parser];
-            return parser;
-        }
-    }
-    
-    return nil;
-}
-
 - (void) _loadObject:(IMBObject*)inObject
 {
-    id parser = [self parserForObject:inObject];
+    id parser = inObject.parser;
     
     
     if ([parser isKindOfClass:[IMBiPhotoParser class]]) {

--- a/ObjectiveFlickr/ObjectiveFlickr.xcodeproj/project.pbxproj
+++ b/ObjectiveFlickr/ObjectiveFlickr.xcodeproj/project.pbxproj
@@ -313,11 +313,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = (
-					ppc,
-					i386,
-					x86_64,
-				);
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -340,7 +336,7 @@
 				);
 				PREBINDING = NO;
 				PRODUCT_NAME = ObjectiveFlickr;
-				VALID_ARCHS = "ppc i386 x86_64";
+				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Debug;
 		};
@@ -348,11 +344,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = (
-					ppc,
-					i386,
-					x86_64,
-				);
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -374,7 +366,7 @@
 				);
 				PREBINDING = NO;
 				PRODUCT_NAME = ObjectiveFlickr;
-				VALID_ARCHS = "ppc i386 x86_64";
+				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Release;
 		};
@@ -402,7 +394,7 @@
 		6ABF72D20F939BB800B9179E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_ENABLE_OBJC_GC = supported;
@@ -529,11 +521,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = (
-					ppc,
-					i386,
-					x86_64,
-				);
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -555,7 +543,7 @@
 				);
 				PREBINDING = NO;
 				PRODUCT_NAME = ObjectiveFlickr;
-				VALID_ARCHS = "ppc i386 x86_64";
+				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Test;
 		};


### PR DESCRIPTION
I use parserForObject: to set the parser on all objects loaded by the promise. It is thus available during _loadObject:

Pierre
