### PR TITLE
Fixed issue #33. Note the following:

### DIFF
--- a/IMBLibraryController.m
+++ b/IMBLibraryController.m
@@ -675,10 +675,9 @@ static NSMutableDictionary* sLibraryControllers = nil;
             inOldNode.objects = nil;
 
             // It may well be that inOldNode is already replaced by some other node (see issue #33).
-            // Make sure to treat that one to be the old node.
-            index = [nodes indexOfObjectPassingTest:^BOOL(id obj, NSUInteger idx, BOOL *stop) {
-                return [inOldNode isEqual:obj];
-            }];
+            // Make sure to treat that one to be the old node (nodes are equal but not necessarily identical).
+            
+            index = [nodes indexOfObject:inOldNode];
 
             if (index != NSNotFound)
             {

--- a/IMBNodeViewController.m
+++ b/IMBNodeViewController.m
@@ -792,7 +792,12 @@ static NSString* kIMBSelectNodeWithIdentifierNotification = @"IMBSelectNodeWithI
 
 - (void) _nodesWillChange
 {
-
+    // Due to an error in NSTreeController a node to be replaced by another node will not be released
+    // by NSTreeController if it was currently selected. As a workaround we can safely unselect it here
+    // before nodes are exchanged by the library controller because the node identifier
+    // of the currently selected node is saved in _selectedNodeIdentfiers anyways.
+    
+    [ibNodeTreeController setSelectionIndexPath:nil];
 }
 
 

--- a/IMBParser.m
+++ b/IMBParser.m
@@ -421,7 +421,10 @@
 	
 	if (inOldNode.isPopulated)
 	{
-		[self populateNode:inNewNode options:inOptions error:&error];
+        if (!inNewNode.isPopulated)
+        {
+            [self populateNode:inNewNode options:inOptions error:&error];
+        }
 		
 		for (IMBNode* oldSubNode in inOldNode.subNodes)
 		{

--- a/IMBTestAppDelegate.m
+++ b/IMBTestAppDelegate.m
@@ -111,6 +111,7 @@
 	[defaults registerDefaults:defaultDefaults];
 	[controller setInitialValues:defaultDefaults];
 	
+    NSLog(@"Garbage Collection is %@", [NSGarbageCollector defaultCollector] != nil ? @"ON" : @"OFF");
 	
 	[pool release];
 }

--- a/IMBiPhotoParser.m
+++ b/IMBiPhotoParser.m
@@ -259,6 +259,7 @@
 		node.leaf = inOldNode.leaf;
 		node.parser = self;
 		node.attributes = inOldNode.attributes;
+        node.isTopLevelNode = inOldNode.isTopLevelNode;
 	}
 	
 	// If we have more than one library then append the library name to the root node...

--- a/iMedia.xcodeproj/project.pbxproj
+++ b/iMedia.xcodeproj/project.pbxproj
@@ -2042,6 +2042,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D0CF005310C50908009EC68F /* IMBTargetDebug.xcconfig */;
 			buildSettings = {
+				GCC_ENABLE_OBJC_GC = unsupported;
 				INFOPLIST_FILE = "TestApp-Info.plist";
 				INSTALL_PATH = "$(HOME)/Applications";
 				OTHER_LDFLAGS = (
@@ -2058,6 +2059,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D0CF005410C50908009EC68F /* IMBTargetRelease.xcconfig */;
 			buildSettings = {
+				GCC_ENABLE_OBJC_GC = unsupported;
 				INFOPLIST_FILE = "TestApp-Info.plist";
 				INSTALL_PATH = "$(HOME)/Applications";
 				OTHER_LDFLAGS = (


### PR DESCRIPTION
- Also provided a workaround for a bug on NSTreeController leaking IMBNodes if one is currently selected while the node tree is being reloaded (look for -[IMBNodeViewController _nodesWillChange])
- Included a fix to -topLevelNodeForParser: from Peter
- Changed the the build settings of iMedia Tester so it doesn't do garbage collection by default (also added log statement telling whether garbage collection is on or not)
