### PR TITLE
Bug fix with NSError zombie being referenced from IMBFolderParser

### DIFF
--- a/IMBFolderParser.m
+++ b/IMBFolderParser.m
@@ -196,11 +196,15 @@
 	NSAutoreleasePool* pool = nil;
 	NSInteger index = 0;
 	
-	NSArray* files = [fm contentsOfDirectoryAtPath:folder error:&error];
-	files = [files sortedArrayUsingSelector:@selector(imb_finderCompare:)];
-	
-	if (error == nil)
+	NSArray* files = [fm contentsOfDirectoryAtPath:folder error:&error];	
+	if (files)
 	{
+		// Non-nil result from contentsOfDirectoryAtPath means we must ignore any value it put into error.
+		// It's likely to be an autoreleased, or zombie object that we can't trust the lifespan of.
+		error = nil;
+		
+		files = [files sortedArrayUsingSelector:@selector(imb_finderCompare:)];
+	
 		NSMutableArray* subnodes = [NSMutableArray array];
 		NSMutableArray* objects = [NSMutableArray arrayWithCapacity:files.count];
 		
@@ -278,13 +282,16 @@
 				subnode.watcherType = kIMBWatcherTypeNone;	// subfolders. See IMBLibraryController _reloadNodesWithWatchedPath:
 				
 				// Should this folder be a leaf or not?  We are going to have to scan into the directory
-			
+				
 				NSArray* folderContents = [fm contentsOfDirectoryAtPath:folder error:&error];	// When we go 10.6 only, use better APIs.
 				BOOL hasSubDir = NO;
 				int fileCounter = 0;	// bail if this is a really full folder
 				
 				if (folderContents)
 				{
+					// As avoid, above propagating an error unless the response was nil
+					error = nil;
+					
 					for (NSString *isThisADirectory in folderContents)
 					{
 						NSString* path = [folder stringByAppendingPathComponent:isThisADirectory];

--- a/IMBLibraryController.m
+++ b/IMBLibraryController.m
@@ -249,6 +249,9 @@ static NSMutableDictionary* sLibraryControllers = nil;
 	else
 	{
 		[self performSelectorOnMainThread:@selector(_presentError:) withObject:error];
+
+		// If we failed then the _oldNode is still good but needs to have its status updated 
+		self.oldNode.badgeTypeNormal = kIMBBadgeTypeNone;
 	}
 }
 
@@ -286,6 +289,9 @@ static NSMutableDictionary* sLibraryControllers = nil;
 		else
 		{
 			[self performSelectorOnMainThread:@selector(_presentError:) withObject:error];
+			
+			// If we failed then the _oldNode is still good but needs to have its status updated 
+			self.oldNode.badgeTypeNormal = kIMBBadgeTypeNone;
 		}
 	}
 }

--- a/IMBLightroom4Parser.h
+++ b/IMBLightroom4Parser.h
@@ -1,13 +1,66 @@
-//
-//  IMBLightroom4Parser.h
-//  iMedia
-//
-//  Created by Pierre Bernard on 6/3/12.
-//  Copyright (c) 2012 Houdah Software. All rights reserved.
-//
+/*
+ iMedia Browser Framework <http://karelia.com/imedia/>
+ 
+ Copyright (c) 2005-2012 by Karelia Software et al.
+ 
+ iMedia Browser is based on code originally developed by Jason Terhorst,
+ further developed for Sandvox by Greg Hulands, Dan Wood, and Terrence Talbot.
+ The new architecture for version 2.0 was developed by Peter Baumgartner.
+ Contributions have also been made by Matt Gough, Martin Wennerberg and others
+ as indicated in source files.
+ 
+ The iMedia Browser Framework is licensed under the following terms:
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in all or substantial portions of the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to permit
+ persons to whom the Software is furnished to do so, subject to the following
+ conditions:
+ 
+ Redistributions of source code must retain the original terms stated here,
+ including this list of conditions, the disclaimer noted below, and the
+ following copyright notice: Copyright (c) 2005-2012 by Karelia Software et al.
+ 
+ Redistributions in binary form must include, in an end-user-visible manner,
+ e.g., About window, Acknowledgments window, or similar, either a) the original
+ terms stated here, including this list of conditions, the disclaimer noted
+ below, and the aforementioned copyright notice, or b) the aforementioned
+ copyright notice and a link to karelia.com/imedia.
+ 
+ Neither the name of Karelia Software, nor Sandvox, nor the names of
+ contributors to iMedia Browser may be used to endorse or promote products
+ derived from the Software without prior and express written permission from
+ Karelia Software or individual contributors, as appropriate.
+ 
+ Disclaimer: THE SOFTWARE IS PROVIDED BY THE COPYRIGHT OWNER AND CONTRIBUTORS
+ "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+ LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+ AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN CONNECTION WITH, THE
+ SOFTWARE OR THE USE OF, OR OTHER DEALINGS IN, THE SOFTWARE.
+ */
+
+
+// Author: Pierre Bernard
+
+
+//----------------------------------------------------------------------------------------------------------------------
+
+
+#pragma mark HEADERS
 
 #import "IMBLightroomParser.h"
 
+
 @interface IMBLightroom4Parser : IMBLightroomParser
+{
+	
+}
 
 @end
+
+
+//----------------------------------------------------------------------------------------------------------------------

--- a/IMBLightroom4Parser.h
+++ b/IMBLightroom4Parser.h
@@ -1,0 +1,13 @@
+//
+//  IMBLightroom4Parser.h
+//  iMedia
+//
+//  Created by Pierre Bernard on 6/3/12.
+//  Copyright (c) 2012 Houdah Software. All rights reserved.
+//
+
+#import "IMBLightroomParser.h"
+
+@interface IMBLightroom4Parser : IMBLightroomParser
+
+@end

--- a/IMBLightroom4Parser.m
+++ b/IMBLightroom4Parser.m
@@ -1,0 +1,13 @@
+//
+//  IMBLightroom4Parser.m
+//  iMedia
+//
+//  Created by Pierre Bernard on 6/3/12.
+//  Copyright (c) 2012 Houdah Software. All rights reserved.
+//
+
+#import "IMBLightroom4Parser.h"
+
+@implementation IMBLightroom4Parser
+
+@end

--- a/IMBLightroom4Parser.m
+++ b/IMBLightroom4Parser.m
@@ -1,13 +1,519 @@
-//
-//  IMBLightroom4Parser.m
-//  iMedia
-//
-//  Created by Pierre Bernard on 6/3/12.
-//  Copyright (c) 2012 Houdah Software. All rights reserved.
-//
+/*
+ iMedia Browser Framework <http://karelia.com/imedia/>
+ 
+ Copyright (c) 2005-2012 by Karelia Software et al.
+ 
+ iMedia Browser is based on code originally developed by Jason Terhorst,
+ further developed for Sandvox by Greg Hulands, Dan Wood, and Terrence Talbot.
+ The new architecture for version 2.0 was developed by Peter Baumgartner.
+ Contributions have also been made by Matt Gough, Martin Wennerberg and others
+ as indicated in source files.
+ 
+ The iMedia Browser Framework is licensed under the following terms:
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in all or substantial portions of the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to permit
+ persons to whom the Software is furnished to do so, subject to the following
+ conditions:
+ 
+ Redistributions of source code must retain the original terms stated here,
+ including this list of conditions, the disclaimer noted below, and the
+ following copyright notice: Copyright (c) 2005-2012 by Karelia Software et al.
+ 
+ Redistributions in binary form must include, in an end-user-visible manner,
+ e.g., About window, Acknowledgments window, or similar, either a) the original
+ terms stated here, including this list of conditions, the disclaimer noted
+ below, and the aforementioned copyright notice, or b) the aforementioned
+ copyright notice and a link to karelia.com/imedia.
+ 
+ Neither the name of Karelia Software, nor Sandvox, nor the names of
+ contributors to iMedia Browser may be used to endorse or promote products
+ derived from the Software without prior and express written permission from
+ Karelia Software or individual contributors, as appropriate.
+ 
+ Disclaimer: THE SOFTWARE IS PROVIDED BY THE COPYRIGHT OWNER AND CONTRIBUTORS
+ "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+ LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+ AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN CONNECTION WITH, THE
+ SOFTWARE OR THE USE OF, OR OTHER DEALINGS IN, THE SOFTWARE.
+ */
+
+
+// Author: Pierre Bernard
+
+
+//----------------------------------------------------------------------------------------------------------------------
+
+
+#pragma mark HEADERS
 
 #import "IMBLightroom4Parser.h"
 
+#import <Quartz/Quartz.h>
+
+#import "FMDatabase.h"
+#import "IMBNode.h"
+#import "IMBNodeObject.h"
+#import "IMBObject.h"
+#import "NSData+SKExtensions.h"
+#import "NSFileManager+iMedia.h"
+#import "NSImage+iMedia.h"
+#import "NSWorkspace+iMedia.h"
+
+
+@interface IMBLightroom4Parser ()
+
+- (NSNumber*) databaseVersion;
+
+@end
+
+
 @implementation IMBLightroom4Parser
+
+//----------------------------------------------------------------------------------------------------------------------
+
+
+// Check if Lightroom is installed...
+
++ (NSString*) lightroomPath
+{
+	return [[NSWorkspace imb_threadSafeWorkspace] absolutePathForAppBundleWithIdentifier:@"com.adobe.Lightroom4"];
+}
+
+
+// Return an array to Lightroom library files...
+
++ (NSArray*) libraryPaths
+{
+	NSMutableArray* libraryPaths = [NSMutableArray array];
+    
+	CFStringRef recentLibrariesList = CFPreferencesCopyAppValue((CFStringRef)@"recentLibraries20",(CFStringRef)@"com.adobe.Lightroom4");
+	
+	if (recentLibrariesList) {
+        [self parseRecentLibrariesList:(NSString*)recentLibrariesList into:libraryPaths];
+        CFRelease(recentLibrariesList);
+	}
+	
+    if ([libraryPaths count] == 0) {
+		CFPropertyListRef activeLibraryPath = CFPreferencesCopyAppValue((CFStringRef)@"libraryToLoad20",(CFStringRef)@"com.adobe.Lightroom4");
+		
+		if (activeLibraryPath) {
+			CFRelease(activeLibraryPath);
+		}
+    }
+    
+	return libraryPaths;
+}
+
++ (NSArray*) concreteParserInstancesForMediaType:(NSString*)inMediaType
+{
+	NSMutableArray* parserInstances = [NSMutableArray array];
+	
+	if ([self isInstalled]) {
+		NSArray* libraryPaths = [self libraryPaths];
+		
+		for (NSString* libraryPath in libraryPaths) {
+			NSString* dataPath = [[[libraryPath stringByDeletingPathExtension]
+								   stringByAppendingString:@" Previews"]
+								  stringByAppendingPathExtension:@"lrdata"];
+			NSFileManager* fileManager = [NSFileManager imb_threadSafeManager];
+			
+			BOOL isDirectory;
+			if (!([fileManager fileExistsAtPath:dataPath isDirectory:&isDirectory] && isDirectory)) {
+				dataPath = nil;
+			}
+			
+			IMBLightroom4Parser* parser = [[[[self class] alloc] initWithMediaType:inMediaType] autorelease];
+			parser.mediaSource = libraryPath;
+			parser.dataPath = dataPath;
+			parser.shouldDisplayLibraryName = libraryPaths.count > 1;
+			
+			// Check database version
+			
+			NSNumber *databaseVersion = [parser databaseVersion];
+			
+			if (databaseVersion != nil) {
+				long databaseVersionLong = [databaseVersion longValue];
+				
+				if (databaseVersionLong < 400020) {
+					continue;
+				}
+				else if (databaseVersionLong >= 500000) {
+					continue;
+				}
+			}
+			
+			[parserInstances addObject:parser];
+		}
+	}
+	
+	return parserInstances;
+}
+
+- (NSNumber*) databaseVersion
+{
+	FMDatabase *database = [self database];
+	NSNumber *databaseVersion = nil;
+	
+	if (database != nil) {		
+		NSString* query =	@" SELECT value"
+		@" FROM Adobe_variablesTable avt"
+		@" WHERE avt.name = ?"
+		@" LIMIT 1";
+		
+		FMResultSet* results = [database executeQuery:query, @"Adobe_DBVersion"];
+		
+		if ([results next]) {				
+			databaseVersion = [NSNumber numberWithLong:[results longForColumn:@"value"]];
+		}
+		
+		[results close];
+	}
+	
+	return databaseVersion;
+}
+
+// This method creates the immediate subnodes of the "Lightroom" root node. The two subnodes are "Folders"  
+// and "Collections"...
+
+- (void) populateSubnodesForRootNode:(IMBNode*)inRootNode
+{
+	NSMutableArray* subNodes = [NSMutableArray array];
+	NSMutableArray* objects = [NSMutableArray array];
+	inRootNode.displayedObjectCount = 0;
+	
+	// Add the Folders node...
+	
+	NSNumber* id_local = [NSNumber numberWithInt:-1];
+	
+	NSString* foldersName = NSLocalizedStringWithDefaultValue(
+															  @"IMBLightroomParser.foldersName",
+															  nil,IMBBundle(),
+															  @"Folders",
+															  @"Name of Folders node in IMBLightroomParser");
+	
+	IMBNode* foldersNode = [[[IMBNode alloc] init] autorelease];
+	foldersNode.mediaSource = self.mediaSource;
+	foldersNode.identifier = [self identifierWithFolderId:id_local];
+	foldersNode.name = foldersName;
+	foldersNode.icon = [self folderIcon];
+	foldersNode.parser = self;
+	foldersNode.attributes = [self attributesWithRootFolder:id_local
+                                                    idLocal:id_local
+                                                   rootPath:nil
+                                               pathFromRoot:nil
+                                                   nodeType:IMBLightroomNodeTypeFolder];
+	foldersNode.leaf = NO;
+	
+	[subNodes addObject:foldersNode];
+	
+	IMBNodeObject* foldersObject = [[[IMBNodeObject alloc] init] autorelease];
+	foldersObject.representedNodeIdentifier = foldersNode.identifier;
+	foldersObject.name = foldersNode.name;
+	foldersObject.metadata = nil;
+	foldersObject.parser = self;
+	foldersObject.index = 0;
+	foldersObject.imageLocation = (id)self.mediaSource;
+	foldersObject.imageRepresentationType = IKImageBrowserNSImageRepresentationType;
+	foldersObject.imageRepresentation = [self largeFolderIcon];
+	
+	[objects addObject:foldersObject];
+	
+	
+	// Add the Collections node...
+	
+	NSString* collectionsName = NSLocalizedStringWithDefaultValue(
+																  @"IMBLightroomParser.collectionsName",
+																  nil,IMBBundle(),
+																  @"Collections",
+																  @"Name of Collections node in IMBLightroomParser");
+	
+	IMBNode* collectionsNode = [[[IMBNode alloc] init] autorelease];
+	collectionsNode.identifier = [self identifierWithCollectionId:[NSNumber numberWithLong:0]];
+	collectionsNode.name = collectionsName;
+	collectionsNode.icon = [self groupIcon];
+	collectionsNode.parser = self;
+	collectionsNode.leaf = NO;
+	
+	[subNodes addObject:collectionsNode];
+	
+	IMBNodeObject* collectionsObject = [[[IMBNodeObject alloc] init] autorelease];
+	collectionsObject.representedNodeIdentifier = collectionsNode.identifier;
+	collectionsObject.name = collectionsNode.name;
+	collectionsObject.metadata = nil;
+	collectionsObject.parser = self;
+	collectionsObject.index = 1;
+	collectionsObject.imageLocation = (id)self.mediaSource;
+	collectionsObject.imageRepresentationType = IKImageBrowserNSImageRepresentationType;
+	collectionsObject.imageRepresentation = [self largeFolderIcon];
+	
+	[objects addObject:collectionsObject];
+	
+	inRootNode.subNodes = subNodes;
+	inRootNode.objects = objects;
+	
+	[super populateSubnodesForRootNode:collectionsNode];
+}
+
+
+- (NSString*) rootFolderQuery
+{
+	NSString* query =	@" SELECT id_local, absolutePath, name"
+	@" FROM AgLibraryRootFolder"
+	@" ORDER BY name ASC";
+	
+	return query;
+}
+
+- (NSString*) folderNodesQuery
+{
+	NSString* query =	@" SELECT id_local, pathFromRoot"
+	@" FROM AgLibraryFolder"
+	@" WHERE rootFolder = ?"
+	@" AND (pathFromRoot LIKE ? AND NOT (pathFromRoot LIKE ?))"
+	@" ORDER BY pathFromRoot ASC";
+	
+	
+	return query;
+}
+
+- (NSString*) rootCollectionNodesQuery
+{
+	NSString* query =	@" SELECT alc.id_local, alc.parent, alc.name"
+	@" FROM AgLibraryCollection alc"
+	@" WHERE (creationId = 'com.adobe.ag.library.collection'"
+	@"   OR creationId = 'com.adobe.ag.library.group'"
+	@"   OR creationId = 'com.adobe.ag.library.smart_collection'"
+	@" ) "
+	@" AND alc.parent IS NULL";
+	
+	return query;
+}
+
+
+- (NSString*) collectionNodesQuery
+{
+	NSString* query =	@" SELECT alc.id_local, alc.parent, alc.name"
+	@" FROM AgLibraryCollection alc"
+	@" WHERE (creationId = 'com.adobe.ag.library.collection'"
+	@"   OR creationId = 'com.adobe.ag.library.group'"
+	@"   OR creationId = 'com.adobe.ag.library.smart_collection'"
+	@" ) "
+	@" AND alc.parent = ?";
+	
+	return query;
+}
+
+
+- (NSString*) folderObjectsQuery
+{
+	NSString* query =	@" SELECT	alf.idx_filename, ai.id_local, ai.fileHeight, ai.fileWidth, ai.orientation,"
+	@"			iptc.caption"
+	@" FROM AgLibraryFile alf"
+	@" INNER JOIN Adobe_images ai ON alf.id_local = ai.rootFile"
+	@" LEFT JOIN AgLibraryIPTC iptc on ai.id_local = iptc.image"
+	@" WHERE alf.folder in ( "
+	@"		SELECT id_local"
+	@"		FROM AgLibraryFolder"
+	@"		WHERE id_local = ? OR (rootFolder = ? AND (pathFromRoot IS NULL OR pathFromRoot = ''))"
+	@" )"
+	@" AND ai.fileFormat <> 'VIDEO'"
+	@" ORDER BY ai.captureTime ASC";
+	
+	return query;
+}
+
+- (NSString*) collectionObjectsQuery
+{
+	NSString* query =	@" SELECT	arf.absolutePath || '/' || alf.pathFromRoot absolutePath,"
+	@"			aif.idx_filename, ai.id_local, ai.fileHeight, ai.fileWidth, ai.orientation,"
+	@"			iptc.caption"
+	@" FROM AgLibraryFile aif"
+	@" INNER JOIN Adobe_images ai ON aif.id_local = ai.rootFile"
+	@" INNER JOIN AgLibraryFolder alf ON aif.folder = alf.id_local"
+	@" INNER JOIN AgLibraryRootFolder arf ON alf.rootFolder = arf.id_local"
+	@" INNER JOIN AgLibraryCollectionImage alci ON ai.id_local = alci.image"
+	@" LEFT JOIN AgLibraryIPTC iptc on ai.id_local = iptc.image"
+	@" WHERE alci.collection = ?"
+	@" AND ai.fileFormat <> 'VIDEO'"
+	@" ORDER BY ai.captureTime ASC";
+	
+	return query;
+}
+
+- (NSImage*) folderIcon
+{
+	static NSImage* folderIcon = nil;
+	
+	if (folderIcon == nil) {
+		NSString* pathToOtherApp = [[self class] lightroomPath];
+		NSString* pathToModule = [pathToOtherApp stringByAppendingPathComponent:@"Contents/Frameworks/Library.lrmodule"];
+		NSString* pathToResources = [pathToModule stringByAppendingPathComponent:@"Contents/Resources"];
+		NSString* pathToIcon = [pathToResources stringByAppendingPathComponent:@"icon_folder.png"];
+		NSImage* image = [[[NSImage alloc] initByReferencingFile:pathToIcon] autorelease];
+		image = [image imb_imageCroppedToRect:NSMakeRect(2,1,19,16)];
+		
+		if (image == nil) {
+			image = [NSImage imb_sharedGenericFolderIcon];
+		}
+		
+		folderIcon = [image copy];
+	}
+	
+	return folderIcon;
+}
+
+- (NSImage*) groupIcon;
+{
+	static NSImage* groupIcon = nil;
+	
+	if (groupIcon == nil) {
+		NSString* pathToOtherApp = [[self class] lightroomPath];
+		NSString* pathToModule = [pathToOtherApp stringByAppendingPathComponent:@"Contents/Frameworks/Library.lrmodule"];
+		NSString* pathToResources = [pathToModule stringByAppendingPathComponent:@"Contents/Resources"];
+		NSString* pathToIcon = [pathToResources stringByAppendingPathComponent:@"groupCreation.png"];
+		NSImage* image = [[[NSImage alloc] initByReferencingFile:pathToIcon] autorelease];
+		image = [image imb_imageCroppedToRect:NSMakeRect(2,2,19,16)];
+		
+		if (image == nil) {
+			image = [NSImage imb_sharedGenericFolderIcon];
+		}
+		
+		groupIcon = [image copy];
+	}
+	
+	return groupIcon;
+}
+
+- (NSImage*) collectionIcon;
+{
+	static NSImage* collectionIcon = nil;
+	
+	if (collectionIcon == nil) {
+		NSString* pathToOtherApp = [[self class] lightroomPath];
+		NSString* pathToModule = [pathToOtherApp stringByAppendingPathComponent:@"Contents/Frameworks/Library.lrmodule"];
+		NSString* pathToResources = [pathToModule stringByAppendingPathComponent:@"Contents/Resources"];
+		NSString* pathToIcon = [pathToResources stringByAppendingPathComponent:@"collectionCreation.png"];
+		NSImage* image = [[[NSImage alloc] initByReferencingFile:pathToIcon] autorelease];
+		image = [image imb_imageCroppedToRect:NSMakeRect(1,1,19,16)];
+		
+		if (image == nil) {
+			image = [NSImage imb_sharedGenericFolderIcon];
+		}
+		
+		collectionIcon = [image copy];
+	}
+	
+	return collectionIcon;
+}
+
+- (NSString*)pyramidPathForImage:(NSNumber*)idLocal
+{
+	FMDatabase *database = [self database];
+	NSString *uuid = nil;
+	NSString *digest = nil;
+	
+	if (database != nil) {	
+		NSString* query =	@" SELECT alf.id_global uuid, ids.digest"
+		@" FROM Adobe_imageDevelopSettings ids"
+		@" INNER JOIN Adobe_images ai ON ai.id_local = ids.image"
+		@" INNER JOIN AgLibraryFile alf on alf.id_local = ai.rootFile"
+		@" WHERE ids.image = ?"
+		@" ORDER BY alf.id_global ASC"
+		@" LIMIT 1";
+		
+		FMResultSet* results = [database executeQuery:query, idLocal];
+		
+		if ([results next]) {				
+			uuid = [results stringForColumn:@"uuid"];
+			digest = [results stringForColumn:@"digest"];
+		}
+		
+		[results close];
+	}
+	
+	if ((uuid != nil) && (digest != nil)) {
+		NSString* prefixOne = [uuid substringToIndex:1];
+		NSString* prefixFour = [uuid substringToIndex:4];
+		NSString* fileName = [[NSString stringWithFormat:@"%@-%@", uuid, digest] stringByAppendingPathExtension:@"lrprev"];
+		
+		return [[prefixOne stringByAppendingPathComponent:prefixFour] stringByAppendingPathComponent:fileName];
+	}
+	
+	return nil;
+}
+
+- (NSData*)previewDataForObject:(IMBObject*)inObject
+{	
+	IMBLightroomObject* lightroomObject = (IMBLightroomObject*)inObject;
+	NSString* absolutePyramidPath = [lightroomObject absolutePyramidPath];
+	
+	if (absolutePyramidPath != nil) {
+		NSData* data = [NSData dataWithContentsOfMappedFile:absolutePyramidPath];
+		
+		//		'AgHg'					-- a magic marker
+		//		header length			-- 2 bytes, big endian includes marker and length
+		//		version					-- 1 byte, zero for now
+		//		kind					-- 1 bytes, 0 == string, 1 == blob
+		//		data length				-- 8 bytes, big endian
+		//		data padding length		-- 8 bytes, big endian
+		//		name					-- zero terminated
+		//		< padding for rest of header >
+		//		< data >
+		//		< data padding >
+		
+		const char pattern[4] = { 0x41, 0x67, 0x48, 0x67 };
+		NSUInteger index = [data lastIndexOfBytes:pattern length:4];
+		
+		if (index != NSNotFound) {
+			unsigned short headerLengthValue; // size 2
+			unsigned long long dataLengthValue; // size 8
+			
+			[data getBytes:&headerLengthValue range:NSMakeRange(index + 4, 2)];
+			[data getBytes:&dataLengthValue range:NSMakeRange(index + 4 + 2 + 1 + 1, 8)];
+			
+			headerLengthValue = NSSwapBigShortToHost(headerLengthValue);
+			dataLengthValue = NSSwapBigLongLongToHost(dataLengthValue);
+			
+			NSData* jpegData = nil;
+            
+            if ((index + headerLengthValue + dataLengthValue) < [data length]) {
+                [data subdataWithRange:NSMakeRange(index + headerLengthValue, dataLengthValue)];
+            }
+            
+			return jpegData;
+		}
+	}
+	
+	return nil;
+}
+
+- (FMDatabase*) libraryDatabase
+{
+	NSString* databasePath = (NSString*)self.mediaSource;
+	FMDatabase* database = [FMDatabase databaseWithPath:databasePath];
+	
+	[database setLogsErrors:YES];
+	
+	return database;
+}
+
+- (FMDatabase*) previewsDatabase
+{
+	NSString* mainDatabasePath = (NSString*)self.mediaSource;
+	NSString* rootPath = [mainDatabasePath stringByDeletingPathExtension];
+	NSString* previewPackagePath = [[NSString stringWithFormat:@"%@ Previews", rootPath] stringByAppendingPathExtension:@"lrdata"];
+	NSString* previewDatabasePath = [[previewPackagePath stringByAppendingPathComponent:@"previews"] stringByAppendingPathExtension:@"db"];
+	FMDatabase* database = [FMDatabase databaseWithPath:previewDatabasePath];
+	
+	[database setLogsErrors:YES];
+	
+	return database;
+}
 
 @end

--- a/IMBLightroom4VideoParser.h
+++ b/IMBLightroom4VideoParser.h
@@ -1,0 +1,13 @@
+//
+//  IMBLightroom4VideoParser.h
+//  iMedia
+//
+//  Created by Pierre Bernard on 6/3/12.
+//  Copyright (c) 2012 Houdah Software. All rights reserved.
+//
+
+#import "IMBLightroomParser.h"
+
+@interface IMBLightroom4VideoParser : IMBLightroomParser
+
+@end

--- a/IMBLightroom4VideoParser.h
+++ b/IMBLightroom4VideoParser.h
@@ -1,13 +1,68 @@
-//
-//  IMBLightroom4VideoParser.h
-//  iMedia
-//
-//  Created by Pierre Bernard on 6/3/12.
-//  Copyright (c) 2012 Houdah Software. All rights reserved.
-//
+/*
+ iMedia Browser Framework <http://karelia.com/imedia/>
+ 
+ Copyright (c) 2005-2012 by Karelia Software et al.
+ 
+ iMedia Browser is based on code originally developed by Jason Terhorst,
+ further developed for Sandvox by Greg Hulands, Dan Wood, and Terrence Talbot.
+ The new architecture for version 2.0 was developed by Peter Baumgartner.
+ Contributions have also been made by Matt Gough, Martin Wennerberg and others
+ as indicated in source files.
+ 
+ The iMedia Browser Framework is licensed under the following terms:
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in all or substantial portions of the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to permit
+ persons to whom the Software is furnished to do so, subject to the following
+ conditions:
+ 
+ Redistributions of source code must retain the original terms stated here,
+ including this list of conditions, the disclaimer noted below, and the
+ following copyright notice: Copyright (c) 2005-2012 by Karelia Software et al.
+ 
+ Redistributions in binary form must include, in an end-user-visible manner,
+ e.g., About window, Acknowledgments window, or similar, either a) the original
+ terms stated here, including this list of conditions, the disclaimer noted
+ below, and the aforementioned copyright notice, or b) the aforementioned
+ copyright notice and a link to karelia.com/imedia.
+ 
+ Neither the name of Karelia Software, nor Sandvox, nor the names of
+ contributors to iMedia Browser may be used to endorse or promote products
+ derived from the Software without prior and express written permission from
+ Karelia Software or individual contributors, as appropriate.
+ 
+ Disclaimer: THE SOFTWARE IS PROVIDED BY THE COPYRIGHT OWNER AND CONTRIBUTORS
+ "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+ LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+ AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN CONNECTION WITH, THE
+ SOFTWARE OR THE USE OF, OR OTHER DEALINGS IN, THE SOFTWARE.
+ */
 
-#import "IMBLightroomParser.h"
 
-@interface IMBLightroom4VideoParser : IMBLightroomParser
+// Author: Peter Baumgartner
+
+
+//----------------------------------------------------------------------------------------------------------------------
+
+
+#pragma mark HEADERS
+
+#import "IMBLightroom4Parser.h"
+
+
+//----------------------------------------------------------------------------------------------------------------------
+
+
+#pragma mark 
+
+@interface IMBLightroom4VideoParser : IMBLightroom4Parser
 
 @end
+
+
+//----------------------------------------------------------------------------------------------------------------------

--- a/IMBLightroom4VideoParser.m
+++ b/IMBLightroom4VideoParser.m
@@ -1,13 +1,158 @@
-//
-//  IMBLightroom4VideoParser.m
-//  iMedia
-//
-//  Created by Pierre Bernard on 6/3/12.
-//  Copyright (c) 2012 Houdah Software. All rights reserved.
-//
+/*
+ iMedia Browser Framework <http://karelia.com/imedia/>
+ 
+ Copyright (c) 2005-2012 by Karelia Software et al.
+ 
+ iMedia Browser is based on code originally developed by Jason Terhorst,
+ further developed for Sandvox by Greg Hulands, Dan Wood, and Terrence Talbot.
+ The new architecture for version 2.0 was developed by Peter Baumgartner.
+ Contributions have also been made by Matt Gough, Martin Wennerberg and others
+ as indicated in source files.
+ 
+ The iMedia Browser Framework is licensed under the following terms:
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in all or substantial portions of the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to permit
+ persons to whom the Software is furnished to do so, subject to the following
+ conditions:
+ 
+ Redistributions of source code must retain the original terms stated here,
+ including this list of conditions, the disclaimer noted below, and the
+ following copyright notice: Copyright (c) 2005-2012 by Karelia Software et al.
+ 
+ Redistributions in binary form must include, in an end-user-visible manner,
+ e.g., About window, Acknowledgments window, or similar, either a) the original
+ terms stated here, including this list of conditions, the disclaimer noted
+ below, and the aforementioned copyright notice, or b) the aforementioned
+ copyright notice and a link to karelia.com/imedia.
+ 
+ Neither the name of Karelia Software, nor Sandvox, nor the names of
+ contributors to iMedia Browser may be used to endorse or promote products
+ derived from the Software without prior and express written permission from
+ Karelia Software or individual contributors, as appropriate.
+ 
+ Disclaimer: THE SOFTWARE IS PROVIDED BY THE COPYRIGHT OWNER AND CONTRIBUTORS
+ "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+ LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+ AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN CONNECTION WITH, THE
+ SOFTWARE OR THE USE OF, OR OTHER DEALINGS IN, THE SOFTWARE.
+ */
+
+
+// Author: Peter Baumgartner
+
+
+//----------------------------------------------------------------------------------------------------------------------
+
+
+#pragma mark HEADERS
 
 #import "IMBLightroom4VideoParser.h"
+#import "IMBParserController.h"
+#import "IMBObject.h"
+#import "NSDictionary+iMedia.h"
+#import "NSURL+iMedia.h"
+
+//----------------------------------------------------------------------------------------------------------------------
+
+
+#pragma mark 
+
+@interface IMBLightroom4VideoParser ()
+
+- (NSString*) metadataDescriptionForMetadata:(NSDictionary*)inMetadata;
+
+@end
+
+
+//----------------------------------------------------------------------------------------------------------------------
+
+
+#pragma mark 
 
 @implementation IMBLightroom4VideoParser
+
+- (NSString*) folderObjectsQuery
+{
+	NSString* query =	@" SELECT	alf.idx_filename, ai.id_local, ai.fileHeight, ai.fileWidth, ai.orientation,"
+	@"			iptc.caption"
+	@" FROM AgLibraryFile alf"
+	@" INNER JOIN Adobe_images ai ON alf.id_local = ai.rootFile"
+	@" LEFT JOIN AgLibraryIPTC iptc on ai.id_local = iptc.image"
+	@" WHERE alf.folder in ( "
+	@"		SELECT id_local"
+	@"		FROM AgLibraryFolder"
+	@"		WHERE id_local = ? OR (rootFolder = ? AND (pathFromRoot IS NULL OR pathFromRoot = ''))"
+	@" )"
+	@" AND ai.fileFormat = 'VIDEO'"
+	@" ORDER BY ai.captureTime ASC";
+	
+	return query;
+}
+
+- (NSString*) collectionObjectsQuery
+{
+	NSString* query =	@" SELECT	arf.absolutePath || '/' || alf.pathFromRoot absolutePath,"
+	@"			aif.idx_filename, ai.id_local, ai.fileHeight, ai.fileWidth, ai.orientation,"
+	@"			iptc.caption"
+	@" FROM AgLibraryFile aif"
+	@" INNER JOIN Adobe_images ai ON aif.id_local = ai.rootFile"
+	@" INNER JOIN AgLibraryFolder alf ON aif.folder = alf.id_local"
+	@" INNER JOIN AgLibraryRootFolder arf ON alf.rootFolder = arf.id_local"
+	@" INNER JOIN AgLibraryCollectionImage alci ON ai.id_local = alci.image"
+	@" LEFT JOIN AgLibraryIPTC iptc on ai.id_local = iptc.image"
+	@" WHERE alci.collection = ?"
+	@" AND ai.fileFormat = 'VIDEO'"
+	@" ORDER BY ai.captureTime ASC";
+	
+	return query;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+
+// Loaded lazily when actually needed for display. Here we combine the metadata we got from the Aperture XML file
+// (which was available immediately, but not enough information) with more information that we obtain via ImageIO.
+// This takes a little longer, but since it only done laziy for those object that are actually visible it's fine.
+// Please note that this method may be called on a background thread...
+
+- (void) loadMetadataForObject:(IMBObject*)inObject
+{
+	NSURL* videoURL = [inObject URL];
+	
+	if (videoURL == nil) {
+		return;
+	}
+	
+	NSMutableDictionary* metadata = [NSMutableDictionary dictionaryWithDictionary:inObject.preliminaryMetadata];
+	
+	[metadata setObject:[inObject path] forKey:@"path"];
+	[metadata addEntriesFromDictionary:[NSURL imb_metadataFromVideoAtURL:videoURL]];
+	
+	NSString* description = [self metadataDescriptionForMetadata:metadata];
+	
+	if ([NSThread isMainThread])
+	{
+		inObject.metadata = metadata;
+		inObject.metadataDescription = description;
+	}
+	else
+	{
+		NSArray* modes = [NSArray arrayWithObject:NSRunLoopCommonModes];
+		[inObject performSelectorOnMainThread:@selector(setMetadata:) withObject:metadata waitUntilDone:NO modes:modes];
+		[inObject performSelectorOnMainThread:@selector(setMetadataDescription:) withObject:description waitUntilDone:NO modes:modes];
+	}
+}
+
+- (NSString*) metadataDescriptionForMetadata:(NSDictionary*)inMetadata
+{
+	return [NSDictionary imb_metadataDescriptionForMovieMetadata:inMetadata];
+}
+
 
 @end

--- a/IMBLightroom4VideoParser.m
+++ b/IMBLightroom4VideoParser.m
@@ -1,0 +1,13 @@
+//
+//  IMBLightroom4VideoParser.m
+//  iMedia
+//
+//  Created by Pierre Bernard on 6/3/12.
+//  Copyright (c) 2012 Houdah Software. All rights reserved.
+//
+
+#import "IMBLightroom4VideoParser.h"
+
+@implementation IMBLightroom4VideoParser
+
+@end

--- a/IMBLightroomParser.m
+++ b/IMBLightroomParser.m
@@ -62,7 +62,9 @@
 #import "IMBLightroom1Parser.h"
 #import "IMBLightroom2Parser.h"
 #import "IMBLightroom3Parser.h"
+#import "IMBLightroom4Parser.h"
 #import "IMBLightroom3VideoParser.h"
+#import "IMBLightroom4VideoParser.h"
 #import "IMBIconCache.h"
 #import "IMBNode.h"
 #import "IMBNodeObject.h"
@@ -281,9 +283,11 @@ static NSArray* sSupportedUTIs = nil;
 		[parserInstances addObjectsFromArray:[IMBLightroom1Parser concreteParserInstancesForMediaType:inMediaType]];
 		[parserInstances addObjectsFromArray:[IMBLightroom2Parser concreteParserInstancesForMediaType:inMediaType]];
 		[parserInstances addObjectsFromArray:[IMBLightroom3Parser concreteParserInstancesForMediaType:inMediaType]];
+		[parserInstances addObjectsFromArray:[IMBLightroom4Parser concreteParserInstancesForMediaType:inMediaType]];
 	}
 	else if ([kIMBMediaTypeMovie isEqualTo:inMediaType]) {
 		[parserInstances addObjectsFromArray:[IMBLightroom3VideoParser concreteParserInstancesForMediaType:inMediaType]];
+		[parserInstances addObjectsFromArray:[IMBLightroom4VideoParser concreteParserInstancesForMediaType:inMediaType]];
 	}
 			  
 	return parserInstances;

--- a/NSString+iMedia.m
+++ b/NSString+iMedia.m
@@ -459,6 +459,14 @@
 			{
 				return nil;
 			}
+			if ([path isEqualToString:symlinkPath])
+			{
+				//
+				// Prevent looping
+				//
+				return path;
+			}
+
 			path = symlinkPath;
 		}
 		else

--- a/iMedia.xcodeproj/project.pbxproj
+++ b/iMedia.xcodeproj/project.pbxproj
@@ -59,6 +59,10 @@
 		8FCA063E12368342009072AE /* IMBApertureHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8FCA063D12368342009072AE /* IMBApertureHeaderView.xib */; };
 		8FCA064212368388009072AE /* IMBApertureHeaderViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 8FCA064012368388009072AE /* IMBApertureHeaderViewController.h */; };
 		8FCA064312368388009072AE /* IMBApertureHeaderViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8FCA064112368388009072AE /* IMBApertureHeaderViewController.m */; };
+		8FF314C515063F6900A76AA2 /* IMBLightroom4Parser.h in Headers */ = {isa = PBXBuildFile; fileRef = 8FF314C315063F6900A76AA2 /* IMBLightroom4Parser.h */; };
+		8FF314C615063F6900A76AA2 /* IMBLightroom4Parser.m in Sources */ = {isa = PBXBuildFile; fileRef = 8FF314C415063F6900A76AA2 /* IMBLightroom4Parser.m */; };
+		8FF314CC15064BC700A76AA2 /* IMBLightroom4VideoParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 8FF314CA15064BC700A76AA2 /* IMBLightroom4VideoParser.h */; };
+		8FF314CD15064BC700A76AA2 /* IMBLightroom4VideoParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 8FF314CB15064BC700A76AA2 /* IMBLightroom4VideoParser.m */; };
 		8FFCBFD010A8CD9C00377C33 /* IMBLightroom3Parser.h in Headers */ = {isa = PBXBuildFile; fileRef = 8FFCBFCE10A8CD9C00377C33 /* IMBLightroom3Parser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8FFCBFD110A8CD9C00377C33 /* IMBLightroom3Parser.m in Sources */ = {isa = PBXBuildFile; fileRef = 8FFCBFCF10A8CD9C00377C33 /* IMBLightroom3Parser.m */; };
 		CE09F303124823020094EC48 /* IMBURLGetSizeOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = CE09F301124823020094EC48 /* IMBURLGetSizeOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -459,6 +463,10 @@
 		8FCA063D12368342009072AE /* IMBApertureHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IMBApertureHeaderView.xib; sourceTree = "<group>"; };
 		8FCA064012368388009072AE /* IMBApertureHeaderViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IMBApertureHeaderViewController.h; sourceTree = "<group>"; };
 		8FCA064112368388009072AE /* IMBApertureHeaderViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IMBApertureHeaderViewController.m; sourceTree = "<group>"; };
+		8FF314C315063F6900A76AA2 /* IMBLightroom4Parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IMBLightroom4Parser.h; sourceTree = "<group>"; };
+		8FF314C415063F6900A76AA2 /* IMBLightroom4Parser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IMBLightroom4Parser.m; sourceTree = "<group>"; };
+		8FF314CA15064BC700A76AA2 /* IMBLightroom4VideoParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IMBLightroom4VideoParser.h; sourceTree = "<group>"; };
+		8FF314CB15064BC700A76AA2 /* IMBLightroom4VideoParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IMBLightroom4VideoParser.m; sourceTree = "<group>"; };
 		8FFCBFCE10A8CD9C00377C33 /* IMBLightroom3Parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IMBLightroom3Parser.h; sourceTree = "<group>"; };
 		8FFCBFCF10A8CD9C00377C33 /* IMBLightroom3Parser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IMBLightroom3Parser.m; sourceTree = "<group>"; };
 		CE09F301124823020094EC48 /* IMBURLGetSizeOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IMBURLGetSizeOperation.h; sourceTree = "<group>"; };
@@ -1076,6 +1084,8 @@
 				8FC2559710A851C500F19642 /* IMBLightroom2Parser.m */,
 				8FFCBFCE10A8CD9C00377C33 /* IMBLightroom3Parser.h */,
 				8FFCBFCF10A8CD9C00377C33 /* IMBLightroom3Parser.m */,
+				8FF314C315063F6900A76AA2 /* IMBLightroom4Parser.h */,
+				8FF314C415063F6900A76AA2 /* IMBLightroom4Parser.m */,
 				8F93177C10A9FC53002CDB19 /* IMBPyramidObjectPromise.h */,
 				8F93177D10A9FC53002CDB19 /* IMBPyramidObjectPromise.m */,
 				8F47B38F10C416050013ED25 /* IMBOrderedDictionary.h */,
@@ -1389,6 +1399,8 @@
 				D0467BB3112C223600C1AA4E /* IMBApertureVideoParser.m */,
 				8FC2089B11C29E1C0083EAB3 /* IMBLightroom3VideoParser.h */,
 				8FC2089C11C29E1C0083EAB3 /* IMBLightroom3VideoParser.m */,
+				8FF314CA15064BC700A76AA2 /* IMBLightroom4VideoParser.h */,
+				8FF314CB15064BC700A76AA2 /* IMBLightroom4VideoParser.m */,
 			);
 			name = Movie;
 			sourceTree = "<group>";
@@ -1527,6 +1539,8 @@
 				30F90B2F13584FE700D13233 /* IMBAppleMediaParser.h in Headers */,
 				30F90B331358501A00D13233 /* IMBFaceObjectViewController.h in Headers */,
 				8F7945CE139518CD0066E133 /* IMBiPhotoObjectPromise.h in Headers */,
+				8FF314C515063F6900A76AA2 /* IMBLightroom4Parser.h in Headers */,
+				8FF314CC15064BC700A76AA2 /* IMBLightroom4VideoParser.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1887,6 +1901,8 @@
 				30F90B3013584FE700D13233 /* IMBAppleMediaParser.m in Sources */,
 				30F90B341358501A00D13233 /* IMBFaceObjectViewController.m in Sources */,
 				8F7945CF139518CD0066E133 /* IMBiPhotoObjectPromise.m in Sources */,
+				8FF314C615063F6900A76AA2 /* IMBLightroom4Parser.m in Sources */,
+				8FF314CD15064BC700A76AA2 /* IMBLightroom4VideoParser.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Hey guys - this is a pretty serious bug. I'm not sure what circumstances cause the behavior where contentsOfDirectoryAtPath:error: returns a non-nil error on success, but I was able to produce it by dragging "/tmp" on my Mac into the Folders section of iMedia. I think the issue is some intermediate error in AppKit gets stuffed in there, but then is released when it's realized that it's not a real error.

Note that in any case these changes are consistent with the rule with NSError returning objects that the value is only valid when the failure condition for the API is met. In this case the failure condition for contentsOfDirectoryAtPath:error: is that the method returns a nil array.
