### PR TITLE
Fix issue 64: Photos and Faces nodes missing in library that draws on Aperture 3.3

### DIFF
--- a/IMBApertureParser.m
+++ b/IMBApertureParser.m
@@ -528,7 +528,17 @@
 
 - (BOOL) isAllPhotosAlbum:(NSDictionary*)inAlbumDict
 {
-	return [[inAlbumDict objectForKey:@"uuid"] isEqualToString:@"allPhotosAlbum"];
+	return ([[inAlbumDict objectForKey:@"uuid"] isEqualToString:@"allPhotosAlbum"] ||
+            [[inAlbumDict objectForKey:@"Album Type"] isEqualToString:@"94"]);
+}
+
+
+//----------------------------------------------------------------------------------------------------------------------
+// Returns whether inAlbumDict is the "Events" (aka "Projects") album.
+
+- (BOOL) isEventsAlbum:(NSDictionary*)inAlbumDict
+{
+	return [[inAlbumDict objectForKey:@"Album Type"] isEqualToString:@"97"];
 }
 
 
@@ -591,7 +601,7 @@
 	static const IMBIconTypeMappingEntry kIconTypeMappingEntries[] =
 	{
 		{@"v3-Photo Stream",@"SL-stream.tiff",          @"folder",	nil,	nil},   // photo stream
-		{@"v3-Faces",@"sl-icon-small_people.tiff",		@"folder",	nil,	nil},   // faces
+		{@"v3-Faces",@"SL-faces.tiff",                  @"folder",	nil,	nil},   // faces
 		{@"v3-1",	@"SL-album.tiff",					@"folder",	nil,	nil},	// album
 		{@"v3-2",	@"SL-smartAlbum.tiff",				@"folder",	nil,	nil},	// smart album
 		{@"v3-3",	@"SL-smartAlbum.tiff",				@"folder",	nil,	nil},	// library **** ... 200X

--- a/IMBAppleMediaParser.h
+++ b/IMBAppleMediaParser.h
@@ -91,6 +91,7 @@
 #define EVENTS_NODE_ID       UINT_MAX-4811	// Very, very unlikely this not to be unique throughout library
 #define FACES_NODE_ID        UINT_MAX-4812	// Very, very unlikely this not to be unique throughout library
 #define PHOTO_STREAM_NODE_ID UINT_MAX-4813	// Very, very unlikely this not to be unique throughout library
+#define ALL_PHOTOS_NODE_ID   UINT_MAX-4814	// Very, very unlikely this not to be unique throughout library
 
 // node object types of interest for skimming
 
@@ -129,6 +130,11 @@ extern NSString* const kIMBiPhotoNodeObjectTypeFace;  // = @"faces"
 // Returns the index of the all photos album ("Photos") in given album list
 
 - (NSUInteger) indexOfAllPhotosAlbumInAlbumList:(NSArray*)inAlbumList;
+
+// Returns the index of the projects album ("Projects") in given album list
+// Projects are to Aperture what events are to iPhoto - hence the method name for coherence
+
+- (NSUInteger) indexOfEventsAlbumInAlbumList:(NSArray*)inAlbumList;
 
 // Returns the index of the flagged album ("Flagged") in given album list
 

--- a/IMBiPhotoParser.m
+++ b/IMBiPhotoParser.m
@@ -705,6 +705,15 @@
 
 
 //----------------------------------------------------------------------------------------------------------------------
+// Returns whether inAlbumDict is the "Events" album.
+
+- (BOOL) isEventsAlbum:(NSDictionary*)inAlbumDict
+{
+	return [[inAlbumDict objectForKey:@"Album Type"] isEqualToString:@"Events"];
+}
+
+
+//----------------------------------------------------------------------------------------------------------------------
 
 
 - (BOOL) isFlaggedAlbum:(NSDictionary*)inAlbumDict


### PR DESCRIPTION
There will be a very similar commit in iMedia 3.0.
