### PR TITLE
iPhoto pasteboard format mimicry

### DIFF
--- a/IMBObjectViewController.m
+++ b/IMBObjectViewController.m
@@ -44,7 +44,7 @@
 */
 
 
-// Author: Peter Baumgartner
+// Author: Peter Baumgartner, Mike Abdullah
 
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -1902,6 +1902,8 @@ NSString* const IMBObjectViewControllerSegmentedControlKey = @"SegmentedControl"
 //						#endif
 					}
 				}
+                
+                [parser didWriteObjects:promise.objects toPasteboard:inPasteboard];
 				
 				_isDragging = YES;
 				itemsWritten = objects.count;

--- a/IMBParser.h
+++ b/IMBParser.h
@@ -44,7 +44,7 @@
 */
 
 
-// Author: Peter Baumgartner
+// Author: Peter Baumgartner, Mike Abdullah
 
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -173,6 +173,10 @@
 - (NSViewController*) customHeaderViewControllerForNode:(IMBNode*)inNode;
 - (NSViewController*) customObjectViewControllerForNode:(IMBNode*)inNode;
 - (NSViewController*) customFooterViewControllerForNode:(IMBNode*)inNode;
+
+// Informs that some of the receiver's IMBObjects have been written to a pasteboard. Could use this to add some
+// extra parser-specific data to the pasteboard. Default implementation does nothing.
+- (void)didWriteObjects:(NSArray *)objects toPasteboard:(NSPasteboard *)pasteboard;
 
 @end
 

--- a/IMBParser.m
+++ b/IMBParser.m
@@ -44,7 +44,7 @@
 */
 
 
-// Author: Peter Baumgartner
+// Author: Peter Baumgartner, Mike Abdullah
 
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -468,6 +468,11 @@
 	return nil;
 }
 
+
+#pragma mark
+#pragma mark Pasteboard
+
+- (void)didWriteObjects:(NSArray *)objects toPasteboard:(NSPasteboard *)pasteboard; { }
 
 //----------------------------------------------------------------------------------------------------------------------
 

--- a/IMBiPhotoParser.m
+++ b/IMBiPhotoParser.m
@@ -1045,7 +1045,12 @@
 			
 			object.location = (id)path;
 			object.name = name;
-			object.preliminaryMetadata = imageDict;	// This metadata from the XML file is available immediately
+            
+            NSMutableDictionary *metadata = [imageDict mutableCopy];
+            [metadata setObject:key forKey:@"iPhotoKey"];   // so pasteboard-writing code can retrieve it later
+			object.preliminaryMetadata = metadata;	// This metadata from the XML file is available immediately
+            [metadata release];
+            
 			object.metadata = nil;					// Build lazily when needed (takes longer)
 			object.metadataDescription = nil;		// Build lazily when needed (takes longer)
 			object.parser = self;
@@ -1163,5 +1168,21 @@
 
 //----------------------------------------------------------------------------------------------------------------------
 
+
+#pragma mark Pasteboard
+
+- (void)didWriteObjects:(NSArray *)objects toPasteboard:(NSPasteboard *)pasteboard;
+{
+    [super didWriteObjects:objects toPasteboard:pasteboard];
+    
+    // Pretend we're iPhoto and write its custom metadata pasteboard type
+    [pasteboard addTypes:[NSArray arrayWithObject:@"ImageDataListPboardType"] owner:nil];
+    
+    NSArray *values = [objects valueForKey:@"preliminaryMetadata"];
+    NSArray *keys = [values valueForKey:@"iPhotoKey"];
+    NSDictionary *dataList = [[NSDictionary alloc] initWithObjects:values forKeys:keys];
+    [pasteboard setPropertyList:dataList forType:@"ImageDataListPboardType"];
+    [dataList release];
+}
 
 @end

--- a/README.mdown
+++ b/README.mdown
@@ -30,6 +30,10 @@ Recent Release Notes
 
 * The `+[IMBConfig registerDefaults]` method has been made private. You should have no need to call it in your app as `IMBConfig` automatically runs that routine the first time it is used
 
+### 2.5.2
+
+* When dragging or copying iPhoto images, we mimic iPhoto by also including `ImageDataListPboardType` on the pasteboard. This allows iPhoto-aware apps to properly handle image metadata without any knowledge of iMedia
+
 
 Development
 ========


### PR DESCRIPTION
When iPhoto images are added to the pasteboard, provides the extra nicety of supplying `ImageDataListPboardType` just like iPhoto would. This means that apps which have been written to handle iPhoto's pasteboard behaviour will automatically behave the right way when faced with iMedia-sourced drags.

@jjac I had to cheat a bit to keep the iPhoto ID of each image around; does this seem a reasonable hack to you?
