### PR TITLE
Fix Flickr pasteboard/metadata handling

### DIFF
--- a/IMBFlickrNode.m
+++ b/IMBFlickrNode.m
@@ -318,7 +318,7 @@ NSString* const IMBFlickrNodeProperty_UUID = @"uuid";
 		[metadata setObject:[webPageURL absoluteString] forKey:@"webPageURL"];
 		
 		NSURL *quickLookURL = [self imageURLForDesiredSize:kIMBFlickrSizeSpecifierMedium fromPhotoDict:photoDict context:context];
-		[metadata setObject:quickLookURL forKey:@"quickLookURL"];
+		[metadata setObject:[quickLookURL absoluteString] forKey:@"quickLookURL"];
 
 		// But give it a better 'description' without the nested item
 		NSString *descHTML = [[photoDict objectForKey:@"description"] objectForKey:@"_text"];

--- a/IMBFlickrNode.m
+++ b/IMBFlickrNode.m
@@ -315,7 +315,7 @@ NSString* const IMBFlickrNodeProperty_UUID = @"uuid";
 		NSMutableDictionary *metadata = [NSMutableDictionary dictionary];
 		[metadata addEntriesFromDictionary:photoDict];		// give metaData the whole thing!
 		NSURL *webPageURL = [context photoWebPageURLFromDictionary:photoDict];
-		[metadata setObject:webPageURL forKey:@"webPageURL"];
+		[metadata setObject:[webPageURL absoluteString] forKey:@"webPageURL"];
 		
 		NSURL *quickLookURL = [self imageURLForDesiredSize:kIMBFlickrSizeSpecifierMedium fromPhotoDict:photoDict context:context];
 		[metadata setObject:quickLookURL forKey:@"quickLookURL"];

--- a/IMBFlickrObject.m
+++ b/IMBFlickrObject.m
@@ -77,7 +77,10 @@
 
 - (NSURL*) previewItemURL
 {
-	NSURL* quickLookURL = [self.metadata objectForKey:@"quickLookURL"];
+	NSString *quickLookURLString = [self.metadata objectForKey:@"quickLookURL"];
+    if (!quickLookURLString) return nil;
+    
+    NSURL *quickLookURL = [NSURL URLWithString:quickLookURLString];
 	NSURL* previewItemURL = nil;
 	
 	if (quickLookURL)

--- a/IMBFlickrParser.m
+++ b/IMBFlickrParser.m
@@ -164,8 +164,8 @@
 	id obj = [sender representedObject];
 	if ([obj isKindOfClass:[IMBObject class]]) {
 		IMBObject* imbObject = (IMBObject*) obj;
-		NSURL* webPage = [[imbObject metadata] objectForKey:@"webPageURL"];
-		[[NSWorkspace imb_threadSafeWorkspace] openURL:webPage];
+		NSString *webPage = [[imbObject metadata] objectForKey:@"webPageURL"];
+		[[NSWorkspace imb_threadSafeWorkspace] openURL:[NSURL URLWithString:webPage]];
 	} else {
 		NSLog (@"Can't handle this kind of object.");
 	}
@@ -178,12 +178,12 @@
 	id obj = [sender representedObject];
 	if ([obj isKindOfClass:[IMBObject class]]) {
 		IMBObject* imbObject = (IMBObject*) obj;
-		NSURL* webPage = [[imbObject metadata] objectForKey:@"webPageURL"];
+		NSString *webPage = [[imbObject metadata] objectForKey:@"webPageURL"];
 
 		NSPasteboard *pb = [NSPasteboard generalPasteboard];
 		NSArray *types = [NSArray arrayWithObjects:NSStringPboardType, nil];
 		[pb declareTypes:types owner:self];
-		[pb setString:[webPage absoluteString] forType:NSStringPboardType];
+		[pb setString:webPage forType:NSStringPboardType];
 	
 	} else {
 		NSLog (@"Can't handle this kind of object.");


### PR DESCRIPTION
Store strings in metadata rather than URLs so dragging and other pasteboard activity still works. Resolves issue #50
