### PR TITLE
Addressed an Xcode alert of using mktemp

### DIFF
--- a/NSFileManager+iMedia.m
+++ b/NSFileManager+iMedia.m
@@ -206,9 +206,8 @@
 	{
 		strcpy(tempFileNameCString, tempFileTemplateCString);
 
-		char *tmpName = mktemp(tempFileNameCString);
-		
-		tempFilePath = [NSString stringWithUTF8String:tmpName];	
+        mkstemp(tempFileNameCString);
+		tempFilePath = [NSString stringWithUTF8String:tempFileNameCString];	
 		
 		free(tempFileNameCString);
 	}


### PR DESCRIPTION
Quote from Xcode:

> Call to function mktemp is insecure as it always creates or uses
> insecure temporary file. Use mkstemp instead
